### PR TITLE
fix stop fill object field when  property not found by column name

### DIFF
--- a/jodd-db/src/main/java/jodd/db/oom/mapper/DefaultResultSetMapper.java
+++ b/jodd-db/src/main/java/jodd/db/oom/mapper/DefaultResultSetMapper.java
@@ -442,11 +442,11 @@ public class DefaultResultSetMapper extends BaseResultSetMapper {
 								BeanUtil.declared.setProperty(result[currentResult], propertyName, value);
 								resultUsage[currentResult] = true;
 							}
-							colNdx++;
 							resultColumns.add(columnName);
-							continue;
 						}
 					}
+					colNdx++;
+					continue;
 				}
 			}
 			// go to next type, i.e. result


### PR DESCRIPTION
if there is a java class :
@Dbtable("A") 
class A{
   @DbColumn("a")
    public String a;
}
and  a sql: select a,b from A;
the method parseObjects (line 417)，find property by column can't return the b property.
then the logic goto line 453 , the object not filled all columns。


<!--
You Are Awesome! Thank you for your contribution!
-->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/oblac/jodd/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## Current behavior

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## New behavior?

<!-- Please describe the new behavior that PR introduces. -->
